### PR TITLE
Implement Artilce Tag

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -11,25 +11,25 @@ class Article extends Model
     protected $hidden = ['category_id'];
 
     public function createArticle($request) {
-        // $articleName = new Article();
-        // $articleName->title = $request->input('title');
-        // $articleName->description = $request->input('description');
-        // $articleName->content  = $request->input('content');
-        // $articleName->category_id  = $request->input('category_id');
-        // $articleName->status  = $request->input('status');
-        // $articleName->save();
+        // $newArticle = new Article();
+        // $newArticle->title = $request->input('title');
+        // $newArticle->description = $request->input('description');
+        // $newArticle->content  = $request->input('content');
+        // $newArticle->category_id  = $request->input('category_id');
+        // $newArticle->status  = $request->input('status');
+        // $newArticle->save();
 
-        // return $articleName;
+        // return $newArticle;
 
-        return Article::create($request->all());
+        return $this::create($request->all());
     } 
 
     public function getArticles () {
-        return Article::all();
+        return $this::all();
     }
 
     public function getArticle($article) {
-        $articleRetrieved = Article::find($article);
+        $articleRetrieved = $this::find($article);
         $article = $articleRetrieved->category;
         return $articleRetrieved;
     }
@@ -37,5 +37,10 @@ class Article extends Model
     public function category()
     {
         return $this->belongsTo('App\Category');
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany('App\Tag')->withTimestamps();
     }
 }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $tagRetrieved = new Tag();
+        $tagRetrieved = $tagRetrieved->getTags();
+
+        $res = (object) array (
+            'status' => 200,
+            'message' => 'All Tags Fetched Succesfully',
+            'data' => $tagRetrieved
+        );
+        return response()->json($res);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $newTag = new Tag();
+        $newTag = $newTag->createTag($request);
+
+        $res = (object) array (
+            'status' => 200,
+            'message' => "Tag $newTag->tag created successfully",
+            'success' => true,
+            'data' => $newTag
+        );
+        return response()->json($res);
+
+
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $tagId
+     * @return \Illuminate\Http\Response
+     */
+    public function show($tagId)
+    {
+        $tagRetrieved = new Tag();
+        $tagRetrieved = $tagRetrieved->getTag($tagId);
+
+        $res = (object) array (
+            'status' => 201,
+            'message' => "Tag $tagRetrieved->tag Fetched Succesfully",
+            'data' => $tagRetrieved
+        );
+        return response()->json($res);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $tagId
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $tagId)
+    {
+        $tag = new Tag();
+        $tag = $tag->uodateTag($request, $tagId);
+
+        $res = (object) array (
+            'status' => 201,
+            'message' => "Tag $tag[0] Updated to $tag[1] Succesfully"
+        );
+        return response()->json($res);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $tagId
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($tagId)
+    {
+        $tag = new Tag();
+        $tag = $tag->deleteTag($tagId);
+
+        $res = (object) array (
+            'status' => 201,
+            'message' => "Tag $tag->tag Deleted Succesfully"
+        );
+        return response()->json($res);
+    }
+}

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $table = 'tags';
+    protected $fillable = ['tag'];
+
+    public function createTag($request) {
+        return $this::create($request->all());
+    }
+
+    public function findOrCreateTag($tag) {
+        return $this::firstOrCreate(['tag' => $tag]);
+    }
+
+    public function getTags () {
+        return $this::all();
+    }
+
+    public function getTag($tag) {
+        $tagRetrieved = $this::find($tag);
+        return $tagRetrieved;
+    }
+
+    public function uodateTag($request, $tagId) {
+        $tagRetrieved = $this::find($tagId);
+        $oldTag = $tagRetrieved->tag;
+        $tagRetrieved->tag = $request->tag;
+        $tagRetrieved->save();
+
+        $updatedTag = $tagRetrieved->tag;
+
+        return [$oldTag, $updatedTag];
+    }
+
+    public function deleteTag($tagId) {
+        $tagRetrieved = $this::find($tagId);
+        $tagRetrieved->delete();
+
+        return $tagRetrieved;
+    }
+
+    public function article()
+    {
+        return $this->belongsToMany('App\Article')->withTimestamps();
+    }
+}

--- a/database/migrations/2019_05_07_202532_create_tags_table.php
+++ b/database/migrations/2019_05_07_202532_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('tag');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2019_05_07_202923_create_article_tag_table.php
+++ b/database/migrations/2019_05_07_202923_create_article_tag_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateArticleTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('article_id');
+            $table->unsignedInteger('tag_id');
+            $table->foreign('article_id')->references('id')->on('articles');
+            $table->foreign('tag_id')->references('id')->on('tags');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,3 +28,9 @@ Route::get('/category/{categoryId}', 'CategoryController@show');
 Route::post('/category/create', 'CategoryController@store');
 Route::put('/category/{categoryId}', 'CategoryController@update');
 Route::delete('/category/{categoryId}', 'CategoryController@destroy');
+
+Route::get('/tag', 'TagController@index');
+Route::get('/tag/{tagId}', 'TagController@show');
+Route::post('/tag/create', 'TagController@store');
+Route::put('/tag/{tagId}', 'TagController@update');
+Route::delete('/tag/{tagId}', 'TagController@destroy');


### PR DESCRIPTION
#### Description
Implement the article tag functionality

#### Type of change
New feature

#### How Has This Been Tested?
Integration using postman

#### Description of the task to be done
- create tag migration and model
- add many to many relationship between article and tag
- implement CRUD for tag
- update article controller with tag when creating articles

#### How can it be manually tested
- Clone this repo
- Checkout to branch article-tags-implementation
- Run `php artisan migrate` or `php artisan migrate:fresh`
- Use postman to do the below
   - add a category to the database using endpoint 
     `http://127.0.0.1:8000/api/category/create` and JSON body of 
     {
	     "category": "your category"
     }
   - add an article using the endpoint `http://127.0.0.1:8000/api/article/create`
     and json body of 
     {
	   "title": "Biligin",
	   "description": "mark@mark.com",
	   "content": "mark",
	   "category": 4, -> optional
	   "status": true, -> optional
	   "tag": ["NECO LESSON"] -> you can have more than one tag seperated by commas
      }
- You should get a success response if followed appropriate steps
- Go to your database and check the below tables
   - category table
   - article table for the article created
   - tag table for the tag(s) created 
   - article_tag table to view the relationship between article and tag created