### PR TITLE
Implement Update and Delete Category

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -8,7 +8,6 @@ class Category extends Model
 {
     protected $table = 'categories';
     protected $fillable = ['category'];
-    protected $hidden = ['id'];
 
     public function createCategory($request) {
         return Category::create($request->all());
@@ -20,6 +19,24 @@ class Category extends Model
 
     public function getCategory($category) {
         return Category::find($category);
+    }
+
+    public function updateCategory($request, $catId) {
+        $catRetrieved = $this::find($catId);
+        $oldCat = $catRetrieved->category;
+        $catRetrieved->category = $request->category;
+        $catRetrieved->save();
+
+        $updatedCat = $catRetrieved->category;
+
+        return [$oldCat, $updatedCat];
+    }
+
+    public function deleteCategory($catId) {
+        $catRetrieved = $this::find($catId);
+        $catRetrieved->delete();
+
+        return $catRetrieved;
     }
 
     public function article()

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -73,7 +73,7 @@ class ArticleController extends Controller
             \DB::rollback();
 
             $res = (object) array (
-                'status' => 200,
+                'status' => 500,
                 'message' => "Article $newArticle->title not created successfully",
                 'success' => false
             );

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -92,9 +92,24 @@ class CategoryController extends Controller
      * @param  \App\Category  $category
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Category $category)
+    public function update(Request $request, $catId)
     {
-        //
+        if ($catId == 1) {
+            $res = (object) array (
+                'status' => 403,
+                'message' => "This category cannot be updated"
+            ); 
+            return response()->json($res);
+        }
+            
+        $category = new Category();
+        $category = $category->updateCategory($request, $catId);
+
+        $res = (object) array (
+            'status' => 201,
+            'message' => "Category $category[0] Updated to $category[1] Succesfully"
+        );
+        return response()->json($res);
     }
 
     /**
@@ -103,8 +118,23 @@ class CategoryController extends Controller
      * @param  \App\Category  $category
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Category $category)
+    public function destroy($catId)
     {
-        //
+        if ($catId == 1) {
+            $res = (object) array (
+                'status' => 403,
+                'message' => "This category cannot be deleted"
+            ); 
+            return response()->json($res);
+        }
+
+        $category = new Category();
+        $category = $category->deleteCategory($catId);
+
+        $res = (object) array (
+            'status' => 201,
+            'message' => "Category $category->category Deleted Succesfully"
+        );
+        return response()->json($res);
     }
 }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -97,7 +97,7 @@ class TagController extends Controller
     public function update(Request $request, $tagId)
     {
         $tag = new Tag();
-        $tag = $tag->uodateTag($request, $tagId);
+        $tag = $tag->updateTag($request, $tagId);
 
         $res = (object) array (
             'status' => 201,

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -26,7 +26,7 @@ class Tag extends Model
         return $tagRetrieved;
     }
 
-    public function uodateTag($request, $tagId) {
+    public function updateTag($request, $tagId) {
         $tagRetrieved = $this::find($tagId);
         $oldTag = $tagRetrieved->tag;
         $tagRetrieved->tag = $request->tag;

--- a/database/migrations/2019_05_03_161900_create_categories_table.php
+++ b/database/migrations/2019_05_03_161900_create_categories_table.php
@@ -18,6 +18,14 @@ class CreateCategoriesTable extends Migration
             $table->string('category');
             $table->timestamps();
         });
+
+        DB::table('categories')->insert(
+            [
+                'category' => 'uncategorized',
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s')
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
#### Description
Implement the article tag functionality

#### Type of change
New feature

#### How Has This Been Tested?
Integration using postman

#### Description of the task to be done
- implement update function in model and controller of category
- implement delete function in model and controller of category
- correct the spelling of update in tag model and controller
- add default category on migration

#### How can it be manually tested
- Clone this repo
- Checkout to branch article-tags-implementation
- Run `php artisan migrate` or `php artisan migrate:fresh`
- Use postman to do the below
   - add a category to the database using endpoint (POST)
     `http://127.0.0.1:8000/api/category/create` and JSON body of 
     {
	     "category": "new category"
     }
   - check to see if the category was added using the endpoint (GET)
	`http://127.0.0.1:8000/api/category`
   - edit the category using the endpoint (PUT)
     `http://127.0.0.1:8000/api/tag/<categoryID>` and JSON body of 
	 {
	     "category": "category name to change to"
     }
   - Note: replace <categoryID> with the id gotten when you created the 		 
     category or view the category
   - check to see if the category was updated using the endpoint (GET)
	`http://127.0.0.1:8000/api/category`
   - delete the category using the endpoint (DELETE)	 
     `http://127.0.0.1:8000/api/tag/<categoryID>` and JSON body of 
	 {
	     "category": "category name to change to"
     }
   - check to see if the category was deleted using the endpoint
	`http://127.0.0.1:8000/api/category` (GET)

   - lastly, try updating or deleting the default category whose <categoryID> is 1
   - You should get a response saying `This category cannot be updated` or `This category cannot be deleted` based on the request type.